### PR TITLE
Create GitHub Actions workflow for automatic compilation of OpenGMK for Windows computers

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,49 @@
+name: Rust
+
+on:
+  repository_dispatch:
+    types: [build]
+  workflow_dispatch:
+      inputs:
+        name:
+          description: 'Run?'
+          required: true
+          default: 'YES!'
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+    - uses: hecrj/setup-rust-action@master
+      with:
+        rust-version: stable
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '10.x'
+    - run: npm install -g yarn
+    - uses: actions/checkout@v2
+    - name: Rust set up
+      run: |
+        set path="%USERPROFILE%\.cargo\bin"
+        rustup self update
+        rustup update
+        rustup install nightly
+    - name: Run test build for thingy
+      run: cargo +nightly build --release
+    - name: Archive bin
+      run: |
+        cd target/release 
+        7z -tzip a GM8Emulator.zip * -mx0 | grep ing 
+        cd ../..
+        mv target/release/GM8Emulator.zip .
+    - name: Upload artifact
+      uses: actions/upload-artifact@v2
+      with:
+          path: GM8Emulator.zip

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,10 +35,16 @@ jobs:
         rustup self update
         rustup update
         rustup install nightly
+        rustup target add i686-pc-windows-msvc --toolchain=nightly
+        cd "dll-bridge"
+        cargo +nightly build --release
+        mv target/i686-pc-windows-msvc/release/dll-bridge.exe .
+        cd ..
     - name: Run test build for thingy
       run: cargo +nightly build --release
     - name: Archive bin
       run: |
+        mv dll-bridge/dll-bridge.exe target/release
         cd target/release 
         7z -tzip a GM8Emulator.zip * -mx0 | grep ing 
         cd ../..


### PR DESCRIPTION
I wasn't able to compile this on my own computer despite trying a lot, so I created a GitHub Actions workflow for automatic compilation of OpenGMK for Windows computers. Now I'm able to run and test the newest version of OpenGMK right away on my own PC. You can download the resulting artifacts easily after every commit. 