### PR TITLE
gml: Get rid of table lookup in runner to invoke API functions

### DIFF
--- a/gm8emulator/src/action.rs
+++ b/gm8emulator/src/action.rs
@@ -80,7 +80,10 @@ pub enum Body {
 
 #[derive(Serialize, Deserialize)]
 pub enum GmlBody {
-    Function(usize),
+    ContextFunction(gml::ContextFunction),
+    StateFunction(gml::StateFunction),
+    RoutineFunction(gml::RoutineFunction),
+    ValueFunction(gml::ValueFunction),
     Code(Rc<[Instruction]>),
 }
 
@@ -92,8 +95,32 @@ pub enum ReturnType {
 
 impl std::fmt::Debug for GmlBody {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+        use std::ptr;
         match self {
-            GmlBody::Function(fn_id) => write!(f, "Body::Function({:?})", mappings::FUNCTIONS.index(*fn_id).unwrap().0),
+            GmlBody::ContextFunction(func) => {
+                let (fn_id, fn_name) = mappings::FUNCTIONS.entries().enumerate()
+                    .find(|(_, (_, &v))| v.addr() == ptr::from_ref(&func.0) as *const ())
+                    .map_or((0, "<unknown>"), |(i, (k, _))| (i+1, k));
+                write!(f, "Body::ContextFunction({}:{})", fn_id, fn_name)
+            },
+            GmlBody::StateFunction(func) => {
+                let (fn_id, fn_name) = mappings::FUNCTIONS.entries().enumerate()
+                    .find(|(_, (_, &v))| v.addr() == ptr::from_ref(&func.0) as *const ())
+                    .map_or((0, "<unknown>"), |(i, (k, _))| (i+1, k));
+                write!(f, "Body::StateFunction({}:{})", fn_id, fn_name)
+            },
+            GmlBody::RoutineFunction(func) => {
+                let (fn_id, fn_name) = mappings::FUNCTIONS.entries().enumerate()
+                    .find(|(_, (_, &v))| v.addr() == ptr::from_ref(&func.0) as *const ())
+                    .map_or((0, "<unknown>"), |(i, (k, _))| (i+1, k));
+                write!(f, "Body::RoutineFunction({}:{})", fn_id, fn_name)
+            },
+            GmlBody::ValueFunction(func) => {
+                let (fn_id, fn_name) = mappings::FUNCTIONS.entries().enumerate()
+                    .find(|(_, (_, &v))| v.addr() == ptr::from_ref(&func.0) as *const ())
+                    .map_or((0, "<unknown>"), |(i, (k, _))| (i+1, k));
+                write!(f, "Body::ValueFunction({}:{})", fn_id, fn_name)
+            },
             GmlBody::Code(code) => write!(f, "Body::Code({:?})", code),
         }
     }
@@ -123,8 +150,8 @@ impl Tree {
                         // For the FUNCTION execution type, a kernel function name is provided in the action's fn_name.
                         // This is compiled to a function pointer.
                         execution_type::FUNCTION => {
-                            if let Some(fn_id) =
-                                str::from_utf8(&action.fn_name.0).ok().and_then(|n| mappings::FUNCTIONS.get_index(n))
+                            if let Some(function) =
+                                str::from_utf8(&action.fn_name.0).ok().and_then(|n| mappings::FUNCTIONS.get(n))
                             {
                                 output.push(Action {
                                     index: i,
@@ -138,7 +165,13 @@ impl Tree {
                                             &action.param_types,
                                             action.param_count,
                                         )?,
-                                        body: GmlBody::Function(fn_id),
+                                        body: match function {
+                                            gml::Function::Runtime(f) => GmlBody::ContextFunction(gml::FunctionPtr(*f)),
+                                            gml::Function::Engine(f) => GmlBody::StateFunction(gml::FunctionPtr(*f)),
+                                            gml::Function::Volatile(f) |
+                                            gml::Function::Constant(f) => GmlBody::RoutineFunction(gml::FunctionPtr(*f)),
+                                            gml::Function::Pure(f) => GmlBody::ValueFunction(gml::FunctionPtr(*f)),
+                                        },
                                         is_condition: action.is_condition,
                                     },
                                 });
@@ -383,7 +416,10 @@ impl Game {
                             }
 
                             returned_value = match gml_body {
-                                GmlBody::Function(f) => self.invoke(*f, &mut context, &arg_values[..args.len()])?,
+                                GmlBody::ContextFunction(f) => f.0(self, &mut context, &arg_values[..args.len()])?,
+                                GmlBody::StateFunction(f) => f.0(self, &arg_values[..args.len()])?,
+                                GmlBody::RoutineFunction(f) => f.0(self, &arg_values[..args.len()])?,
+                                GmlBody::ValueFunction(f) => f.0(&arg_values[..args.len()])?,
                                 GmlBody::Code(code) => {
                                     context.arguments = arg_values;
                                     context.argument_count = args.len();
@@ -405,7 +441,10 @@ impl Game {
                                 }
 
                                 returned_value = match gml_body {
-                                    GmlBody::Function(f) => self.invoke(*f, &mut context, &arg_values[..args.len()])?,
+                                    GmlBody::ContextFunction(f) => f.0(self, &mut context, &arg_values[..args.len()])?,
+                                    GmlBody::StateFunction(f) => f.0(self, &arg_values[..args.len()])?,
+                                    GmlBody::RoutineFunction(f) => f.0(self, &arg_values[..args.len()])?,
+                                    GmlBody::ValueFunction(f) => f.0(&arg_values[..args.len()])?,
                                     GmlBody::Code(code) => {
                                         context.arguments = arg_values;
                                         context.argument_count = args.len();

--- a/gm8emulator/src/gml.rs
+++ b/gm8emulator/src/gml.rs
@@ -19,24 +19,42 @@ pub use value::Value;
 pub type Result<T> = std::result::Result<T, runtime::Error>;
 pub use runtime::Error;
 
+use serde::{Serialize, Deserialize, ser, de};
+
+#[repr(transparent)]
+#[derive(Clone)]
+pub struct FunctionPtr<T>(pub T);
+
 use crate::game::Game;
+type ContextFunctionPtr = fn(&mut Game, &mut Context, &[Value]) -> Result<Value>;
+type StateFunctionPtr = fn(&mut Game, &[Value]) -> Result<Value>;
+type RoutineFunctionPtr = fn(&Game, &[Value]) -> Result<Value>;
+type ValueFunctionPtr = fn(&[Value]) -> Result<Value>;
+
+pub type ContextFunction = FunctionPtr<ContextFunctionPtr>;
+pub type StateFunction = FunctionPtr<StateFunctionPtr>;
+pub type RoutineFunction = FunctionPtr<RoutineFunctionPtr>;
+pub type ValueFunction = FunctionPtr<ValueFunctionPtr>;
+
 #[derive(Clone, Copy)]
 pub enum Function {
     // accesses and/or changes the program state, depending on the context
-    Runtime(fn(&mut Game, &mut Context, &[Value]) -> Result<Value>),
+    Runtime(ContextFunctionPtr),
 
     // accesses and/or changes the program state
-    Engine(fn(&mut Game, &[Value]) -> Result<Value>),
+    Engine(StateFunctionPtr),
 
     // depends on external state (OS, time etc.) or uses interior mutability
-    Volatile(fn(&Game, &[Value]) -> Result<Value>),
+    Volatile(RoutineFunctionPtr),
 
     // only accesses the program state
-    Constant(fn(&Game, &[Value]) -> Result<Value>),
+    Constant(RoutineFunctionPtr),
 
     // neither uses nor modifies any program state
-    Pure(fn(&[Value]) -> Result<Value>),
+    Pure(ValueFunctionPtr),
 }
+
+use std::ptr;
 
 impl Function {
     pub fn invoke(&self, game: &mut Game, context: &mut Context, args: &[Value]) -> Result<Value> {
@@ -48,9 +66,86 @@ impl Function {
             Self::Pure(f) => f(args),
         }
     }
+
+    pub fn addr(&self) -> *const () {
+        match self {
+            Self::Runtime(f) => ptr::from_ref(f) as *const (),
+            Self::Engine(f) => ptr::from_ref(f) as *const (),
+            Self::Volatile(f) |
+            Self::Constant(f) => ptr::from_ref(f) as *const (),
+            Self::Pure(f) => ptr::from_ref(f) as *const (),
+        }
+    }
 }
 
-use serde::{Deserialize, Serialize};
+impl<T> Serialize for FunctionPtr<T> {
+    fn serialize<S>(&self, s: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        s.serialize_u16(mappings::FUNCTIONS.values()
+            .position(|&x| x.addr() == ptr::from_ref(&self.0) as *const ())
+            .ok_or(ser::Error::custom("function doesn't belong to GML API"))?
+            .try_into().or(Err(ser::Error::custom("function index is too big to serialize")))?
+        )
+    }
+}
+
+impl<'de> Deserialize<'de> for ContextFunction {
+    fn deserialize<D>(d: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let i = u16::deserialize(d)?;
+        if let Some((_, Function::Runtime(f))) = mappings::FUNCTIONS.index(i.into()) {
+            Ok(FunctionPtr(*f))
+        } else {
+            Err(de::Error::custom("deserialized function index is out of range"))
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for StateFunction {
+    fn deserialize<D>(d: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let i = u16::deserialize(d)?;
+        if let Some((_, Function::Engine(f))) = mappings::FUNCTIONS.index(i.into()) {
+            Ok(FunctionPtr(*f))
+        } else {
+            Err(de::Error::custom("deserialized function index is out of range"))
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for RoutineFunction {
+    fn deserialize<D>(d: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let i = u16::deserialize(d)?;
+        if let Some((_, Function::Volatile(f) | Function::Constant(f))) = mappings::FUNCTIONS.index(i.into()) {
+            Ok(FunctionPtr(*f))
+        } else {
+            Err(de::Error::custom("deserialized function index is out of range"))
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for ValueFunction {
+    fn deserialize<D>(d: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let i = u16::deserialize(d)?;
+        if let Some((_, Function::Pure(f))) = mappings::FUNCTIONS.index(i.into()) {
+            Ok(FunctionPtr(*f))
+        } else {
+            Err(de::Error::custom("deserialized function index is out of range"))
+        }
+    }
+}
 
 pub const TRUE: f64 = 1.0;
 pub const FALSE: f64 = 0.0;

--- a/gm8emulator/src/gml/runtime.rs
+++ b/gm8emulator/src/gml/runtime.rs
@@ -41,15 +41,33 @@ pub enum Instruction {
 /// Node representing one value in an expression.
 #[derive(Clone, Serialize, Deserialize)]
 pub enum Node {
-    Literal { value: Value },
     Constant { constant_id: usize },
-    Function { args: Box<[Node]>, function_id: usize },
+    Literal { value: Value },
+    Variable { accessor: VariableAccessor },
+    Field { accessor: FieldAccessor },
+
+    ContextFunction {
+        args: Box<[Node]>,
+        function: gml::ContextFunction
+    },
+    StateFunction {
+        args: Box<[Node]>,
+        function: gml::StateFunction
+    },
+    RoutineFunction {
+        args: Box<[Node]>,
+        function: gml::RoutineFunction,
+    },
+    ValueFunction {
+        args: Box<[Node]>,
+        function: gml::ValueFunction
+    },
+
+    Unary { child: Box<Node>, operator: UnaryOperator },
+    Binary { left: Box<Node>, right: Box<Node>, operator: BinaryOperator, type_unsafe: bool },
     Script { args: Box<[Node]>, script_id: usize },
     ExtensionFunction { args: Box<[Node]>, id: usize },
-    Field { accessor: FieldAccessor },
-    Variable { accessor: VariableAccessor },
-    Binary { left: Box<Node>, right: Box<Node>, operator: BinaryOperator, type_unsafe: bool },
-    Unary { child: Box<Node>, operator: UnaryOperator },
+
     RuntimeError { error: Error },
 }
 
@@ -250,23 +268,48 @@ impl fmt::Debug for Instruction {
 
 impl fmt::Debug for Node {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use std::ptr;
         match self {
+            Node::Constant { constant_id } => write!(f, "<constant {:?}>", constant_id),
             Node::Literal { value } => match value {
                 Value::Real(r) => write!(f, "{:?}", r),
                 Value::Str(s) => write!(f, "{:?}", s),
             },
-            Node::Constant { constant_id } => write!(f, "<constant {:?}>", constant_id),
-            Node::Function { args, function_id } => {
-                write!(f, "<function {:?}: {:?}>", mappings::FUNCTIONS.index(*function_id).unwrap().0, args)
-            },
-            Node::Script { args, script_id } => write!(f, "<script {:?}: {:?}>", script_id, args),
-            Node::ExtensionFunction { args, id } => write!(f, "<extfn {:?}: {:?}>", id, args),
-            Node::Field { accessor } => write!(f, "<field: {:?}>", accessor),
             Node::Variable { accessor } => write!(f, "<variable: {:?}>", accessor),
+            Node::Field { accessor } => write!(f, "<field: {:?}>", accessor),
+
+            Node::ContextFunction { args, function } => {
+                let (fn_id, fn_name) = mappings::FUNCTIONS.entries().enumerate()
+                    .find(|(_, (_, &v))| v.addr() == ptr::from_ref(&function.0) as *const ())
+                    .map_or((0, "*unknown*"), |(i, (k, _))| (i+1, k));
+                write!(f, "<context fn #{}: {}({:?})", fn_id, fn_name, args)
+            },
+            Node::StateFunction { args, function } => {
+                let (fn_id, fn_name) = mappings::FUNCTIONS.entries().enumerate()
+                    .find(|(_, (_, &v))| v.addr() == ptr::from_ref(&function.0) as *const ())
+                    .map_or((0, "*unknown*"), |(i, (k, _))| (i+1, k));
+                write!(f, "<state fn #{}: {}({:?})", fn_id, fn_name, args)
+            },
+            Node::RoutineFunction { args, function } => {
+                let (fn_id, fn_name) = mappings::FUNCTIONS.entries().enumerate()
+                    .find(|(_, (_, &v))| v.addr() == ptr::from_ref(&function.0) as *const ())
+                    .map_or((0, "*unknown*"), |(i, (k, _))| (i+1, k));
+                write!(f, "<routine fn #{}: {}({:?})", fn_id, fn_name, args)
+            },
+            Node::ValueFunction { args, function } => {
+                let (fn_id, fn_name) = mappings::FUNCTIONS.entries().enumerate()
+                    .find(|(_, (_, &v))| v.addr() == ptr::from_ref(&function.0) as *const ())
+                    .map_or((0, "*unknown*"), |(i, (k, _))| (i+1, k));
+                write!(f, "<value fn #{}: {}({:?})", fn_id, fn_name, args)
+            },
+
+            Node::Unary { child, operator } => write!(f, "<unary {:?}: {:?}>", operator, child),
             Node::Binary { left, right, operator, type_unsafe } => {
                 write!(f, "<binary {:?}: {:?}, {:?}, {:?}>", operator, left, right, type_unsafe)
             },
-            Node::Unary { child, operator } => write!(f, "<unary {:?}: {:?}>", operator, child),
+            Node::Script { args, script_id } => write!(f, "<script {:?}: {:?}>", script_id, args),
+            Node::ExtensionFunction { args, id } => write!(f, "<extfn {:?}: {:?}>", id, args),
+
             Node::RuntimeError { error } => write!(f, "<error: {:?}>", error),
         }
     }
@@ -312,10 +355,6 @@ impl UnaryOperator {
 }
 
 impl Game {
-    pub fn invoke(&mut self, function_id: usize, context: &mut Context, args: &[Value]) -> gml::Result<Value> {
-        mappings::FUNCTIONS.index(function_id).unwrap().1.invoke(self, context, args)
-    }
-
     pub fn execute(&mut self, instructions: &[Instruction], context: &mut Context) -> gml::Result<ReturnType> {
         for instruction in instructions.iter() {
             match self.exec_instruction(instruction, context)? {
@@ -579,12 +618,33 @@ impl Game {
                     Err(gml::Error::NonexistentAsset(asset::Type::Constant, *constant_id as i32))
                 }
             },
-            Node::Function { args, function_id } => {
+            Node::ContextFunction { args, function } => {
                 let mut arg_values: [Value; 16] = Default::default();
                 for (src, dest) in args.iter().zip(arg_values.iter_mut()) {
                     *dest = self.eval(src, context)?;
                 }
-                self.invoke(*function_id, context, &arg_values[..args.len()])
+                function.0(self, context, &arg_values[..args.len()])
+            },
+            Node::StateFunction { args, function } => {
+                let mut arg_values: [Value; 16] = Default::default();
+                for (src, dest) in args.iter().zip(arg_values.iter_mut()) {
+                    *dest = self.eval(src, context)?;
+                }
+                function.0(self, &arg_values[..args.len()])
+            },
+            Node::RoutineFunction { args, function } => {
+                let mut arg_values: [Value; 16] = Default::default();
+                for (src, dest) in args.iter().zip(arg_values.iter_mut()) {
+                    *dest = self.eval(src, context)?;
+                }
+                function.0(self, &arg_values[..args.len()])
+            },
+            Node::ValueFunction { args, function } => {
+                let mut arg_values: [Value; 16] = Default::default();
+                for (src, dest) in args.iter().zip(arg_values.iter_mut()) {
+                    *dest = self.eval(src, context)?;
+                }
+                function.0(&arg_values[..args.len()])
             },
             Node::Script { args, script_id } => {
                 if let Some(Some(script)) = self.assets.scripts.get(*script_id) {


### PR DESCRIPTION
This resolves #97.
But I'm not sure my code, as a Rust rookie, is anywhere close to proper here, so I need feedback, and I really want critique!