### PR TITLE
Add lowercase support to ord

### DIFF
--- a/gm8emulator/src/gml/kernel.rs
+++ b/gm8emulator/src/gml/kernel.rs
@@ -4119,7 +4119,14 @@ impl Game {
     }
 
     pub fn ord(args: &[Value]) -> gml::Result<Value> {
-        expect_args!(args, [bytes]).map(|s| s.as_ref().get(0).copied().map(f64::from).unwrap_or_default().into())
+        expect_args!(args, [bytes]).map(|s| {
+            let v = s.as_ref().get(0).copied().map(|b| {
+                // Allows lowercase letters to be accepted
+                let b = if b.is_ascii_lowercase() { b.to_ascii_uppercase() } else { b };
+                f64::from(b)
+            }).unwrap_or_default();
+            v.into()
+        })
     }
 
     pub fn string_length(&self, args: &[Value]) -> gml::Result<Value> {


### PR DESCRIPTION
Changes `ord`'s behavior to allow lowercase characters to be accepted as valid input.

This allows Z, X, and C inputs to be accepted in the UNDERTALE Demo. The input handling using these keys are still imperfect (Menu instantly closes, can't skip dialogue with X), but that is a separate issue.